### PR TITLE
[BUGFIX] Enable use of the API key

### DIFF
--- a/Classes/Service/GeoService.php
+++ b/Classes/Service/GeoService.php
@@ -44,7 +44,7 @@ class GeoService
     /**
      * base URL to fetch the Coordinates (Latitude, Longitutde of a Address String.
      */
-    protected $geocodingUrl = 'http://maps.googleapis.com/maps/api/geocode/json?language=de&sensor=false';
+    protected $geocodingUrl = 'https://maps.googleapis.com/maps/api/geocode/json?language=de&sensor=false';
 
     /**
      * constructor method.
@@ -61,7 +61,7 @@ class GeoService
             $apikey = $geoCodingConfig['googleApiKey'];
         }
         $this->apikey = $apikey;
-        //$this->geocodingUrl .= '&key=' . $apikey;
+        $this->geocodingUrl .= '&key=' . $apikey;
     }
 
     /**


### PR DESCRIPTION
https:// must be used when requesting the API with an API key.