### PR TITLE
Fix check for empty addressPart

### DIFF
--- a/Classes/Service/GeoService.php
+++ b/Classes/Service/GeoService.php
@@ -79,7 +79,7 @@ class GeoService
     {
         $addressParts = [];
         foreach ([$street, $zip . ' ' . $city, $country] as $addressPart) {
-            if (empty($addressPart)) {
+            if (strlen(trim($addressPart)) <= 0) {
                 continue;
             }
             $addressParts[] = trim($addressPart);


### PR DESCRIPTION
Not given zip and city will no longer be added
as empty string to the google API request. This
could lead to two consecutive commas.
As a result the request leads sometimes
to `ZERO_RESULTS`.

Closes #15.